### PR TITLE
Modify: WASD movement to follow mouse (forward vector)  + etc

### DIFF
--- a/lib/src/input.rs
+++ b/lib/src/input.rs
@@ -1,0 +1,21 @@
+pub struct Input {
+    pub key_w: bool,
+    pub key_a: bool,
+    pub key_s: bool,
+    pub key_d: bool,
+    pub key_shift: bool,
+    pub key_space: bool,
+}
+
+impl Input {
+    pub fn new() -> Self {
+        Self {
+            key_w: false,
+            key_a: false,
+            key_s: false,
+            key_d: false,
+            key_shift: false,
+            key_space: false,
+        }
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -437,6 +437,9 @@ pub async fn run() {
                             }
                             if let Some(vox) = vox.as_mut() {
                                 vox.vertical_rotation -= delta_y as f32 * 0.002;
+                                vox.vertical_rotation = vox
+                                    .vertical_rotation
+                                    .clamp(-0.5 * std::f32::consts::PI, 0.5 * std::f32::consts::PI);
                             }
 
                             let center_x: i32 = window_position.x + (window_size.width / 2) as i32;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -434,6 +434,11 @@ pub async fn run() {
                             let delta_y = local_cursor_position.y - (window_size.height / 2) as f64;
                             if let Some(vox) = vox.as_mut() {
                                 vox.horizontal_rotation -= delta_x as f32 * 0.002;
+                                vox.horizontal_rotation %= 2.0 * std::f32::consts::PI;
+                                if vox.horizontal_rotation < 0.0 {
+                                    vox.horizontal_rotation += 2.0 * std::f32::consts::PI;
+                                }
+                                println!("h-r: {}", vox.horizontal_rotation);
                             }
                             if let Some(vox) = vox.as_mut() {
                                 vox.vertical_rotation -= delta_y as f32 * 0.002;


### PR DESCRIPTION
DONE:
- 마우스 시점을 기준으로 WASD 움직임이 따라감
- 기존의 코드에서는 키보드 이벤트가 발생하면 바로 vox.eye의 위치를 수정했는데 이는 OS의 키보드 핸들링에 의존되어 일관된 움직임을 구현하기 어려움.
- 따라서 키보드 이벤트로 pressed/released 여부만 확인하고 Input 구조체에 정보를 저장한 후, 프레임 마다 일정한 거리만큼한 이동하도록 구현. (나중에는 60fps, 144fps등의 다양한 프레임에도 속도가 일정하려면 delta time 기준으로 변경해야함. )


TODO:
- 프로그램 시작시 마우스 움직임이 자연스럽지만, 시점을 180도 돌려, 뒤를 바라보고 마우스를 위아래로 움직이면 위아래가 반전되어 움직이고 있음. 이 버그 해결해야함. (우선 일관된 Transform 구조체를 만들어야할 듯.. 지금 위치,회전 관련 코드가 매우 중구난방...;ㅁ;)
- 현재 이벤트 루프(run함수의)에 프레임마다 호출되는 이벤트는 RedrawRequested밖에 없는 관계로 vox의 movement 구현 코드를 우선 넣어둠. 나중에 어떻게 모듈화할지는 jmaing님과 상의할 예정.