### PR TITLE
Helpful features + Split module +  Better movement logic

### DIFF
--- a/lib/src/input.rs
+++ b/lib/src/input.rs
@@ -4,7 +4,7 @@ use winit::{
     keyboard::{Key, NamedKey},
 };
 
-pub struct Input {
+pub struct InputState {
     pub key_w: bool,
     pub key_a: bool,
     pub key_s: bool,
@@ -13,11 +13,10 @@ pub struct Input {
     pub key_space: bool,
     pub key_esc: bool,
     pub key_tab: bool,
-    pub local_cursor_position: PhysicalPosition<f64>,
 }
 
-impl Input {
-    pub fn new() -> Self {
+impl InputState {
+    fn new() -> Self {
         Self {
             key_w: false,
             key_a: false,
@@ -27,6 +26,19 @@ impl Input {
             key_space: false,
             key_esc: false,
             key_tab: false,
+        }
+    }
+}
+
+pub struct EventDrivenInput {
+    pub input_state: InputState,
+    pub local_cursor_position: PhysicalPosition<f64>,
+}
+
+impl EventDrivenInput {
+    pub fn new() -> Self {
+        Self {
+            input_state: InputState::new(),
             local_cursor_position: PhysicalPosition::new(0.0, 0.0),
         }
     }
@@ -42,21 +54,30 @@ impl Input {
 
     fn set_character_key_state(&mut self, key: &str, state: bool) {
         match key.to_lowercase().as_str() {
-            "w" => self.key_w = state,
-            "a" => self.key_a = state,
-            "s" => self.key_s = state,
-            "d" => self.key_d = state,
+            "w" => self.input_state.key_w = state,
+            "a" => self.input_state.key_a = state,
+            "s" => self.input_state.key_s = state,
+            "d" => self.input_state.key_d = state,
             _ => {}
         }
     }
 
     fn set_named_key_state(&mut self, key: NamedKey, state: bool) {
         match key {
-            NamedKey::Shift => self.key_shift = state,
-            NamedKey::Space => self.key_space = state,
-            NamedKey::Escape => self.key_esc = state,
-            NamedKey::Tab => self.key_tab = state,
+            NamedKey::Shift => self.input_state.key_shift = state,
+            NamedKey::Space => self.input_state.key_space = state,
+            NamedKey::Escape => self.input_state.key_esc = state,
+            NamedKey::Tab => self.input_state.key_tab = state,
             _ => {}
         }
     }
 }
+
+pub struct FrameDrivenInput {
+    pub key_pressed: InputState,
+    pub key_down: InputState,
+    pub key_up: InputState,
+    pub local_cursor_position: PhysicalPosition<f64>,
+}
+
+impl FrameDrivenInput {}

--- a/lib/src/input.rs
+++ b/lib/src/input.rs
@@ -5,6 +5,7 @@ use winit::{
     keyboard::{Key, NamedKey, SmolStr},
 };
 
+/// EventDrivenInput will reset key state when input events occur.
 pub struct EventDrivenInput {
     pub key_pressed: HashMap<Key, bool>,
     pub local_cursor_position: PhysicalPosition<f64>,
@@ -31,6 +32,8 @@ impl EventDrivenInput {
     }
 }
 
+/// FrameDrivenInput will update input states every frame.
+/// Added up & down state for game logic.
 pub struct FrameDrivenInput {
     pub key_pressed: HashMap<Key, bool>,
     pub key_down: HashMap<Key, bool>,

--- a/lib/src/input.rs
+++ b/lib/src/input.rs
@@ -1,83 +1,92 @@
+use std::collections::HashMap;
 use winit::{
     dpi::PhysicalPosition,
     event::ElementState,
-    keyboard::{Key, NamedKey},
+    keyboard::{Key, NamedKey, SmolStr},
 };
 
-pub struct InputState {
-    pub key_w: bool,
-    pub key_a: bool,
-    pub key_s: bool,
-    pub key_d: bool,
-    pub key_shift: bool,
-    pub key_space: bool,
-    pub key_esc: bool,
-    pub key_tab: bool,
-}
-
-impl InputState {
-    fn new() -> Self {
-        Self {
-            key_w: false,
-            key_a: false,
-            key_s: false,
-            key_d: false,
-            key_shift: false,
-            key_space: false,
-            key_esc: false,
-            key_tab: false,
-        }
-    }
-}
-
 pub struct EventDrivenInput {
-    pub input_state: InputState,
+    pub key_pressed: HashMap<Key, bool>,
     pub local_cursor_position: PhysicalPosition<f64>,
 }
 
 impl EventDrivenInput {
     pub fn new() -> Self {
         Self {
-            input_state: InputState::new(),
+            key_pressed: HashMap::new(),
             local_cursor_position: PhysicalPosition::new(0.0, 0.0),
         }
     }
 
     pub fn set_key_state(&mut self, logical_key: Key, state: ElementState) {
         let is_pressed = matches!(state, ElementState::Pressed);
-        match logical_key {
-            Key::Character(s) => self.set_character_key_state(s.as_str(), is_pressed),
-            Key::Named(named_key) => self.set_named_key_state(named_key, is_pressed),
-            _ => {}
-        }
-    }
-
-    fn set_character_key_state(&mut self, key: &str, state: bool) {
-        match key.to_lowercase().as_str() {
-            "w" => self.input_state.key_w = state,
-            "a" => self.input_state.key_a = state,
-            "s" => self.input_state.key_s = state,
-            "d" => self.input_state.key_d = state,
-            _ => {}
-        }
-    }
-
-    fn set_named_key_state(&mut self, key: NamedKey, state: bool) {
-        match key {
-            NamedKey::Shift => self.input_state.key_shift = state,
-            NamedKey::Space => self.input_state.key_space = state,
-            NamedKey::Escape => self.input_state.key_esc = state,
-            NamedKey::Tab => self.input_state.key_tab = state,
-            _ => {}
-        }
+        let key_to_insert = match logical_key {
+            Key::Character(ref s) => {
+                let lowercase_key = SmolStr::new(s.to_lowercase());
+                Key::Character(lowercase_key)
+            }
+            _ => logical_key,
+        };
+        self.key_pressed.insert(key_to_insert, is_pressed);
     }
 }
 
 pub struct FrameDrivenInput {
-    pub key_pressed: InputState,
-    pub key_down: InputState,
-    pub key_up: InputState,
+    pub key_pressed: HashMap<Key, bool>,
+    pub key_down: HashMap<Key, bool>,
+    pub key_up: HashMap<Key, bool>,
     pub local_cursor_position: PhysicalPosition<f64>,
 }
 
-impl FrameDrivenInput {}
+impl FrameDrivenInput {
+    pub fn new() -> Self {
+        Self {
+            key_pressed: HashMap::new(),
+            key_down: HashMap::new(),
+            key_up: HashMap::new(),
+            local_cursor_position: PhysicalPosition::new(0.0, 0.0),
+        }
+    }
+
+    pub fn update(&mut self, event_driven_input: &EventDrivenInput) {
+        let previous_key_pressed = self.key_pressed.clone();
+        self.key_pressed = event_driven_input.key_pressed.clone();
+
+        self.key_down.clear();
+        self.key_up.clear();
+
+        for (key, &is_pressed) in &self.key_pressed {
+            let was_pressed = previous_key_pressed.get(key).cloned().unwrap_or(false);
+            if is_pressed && !was_pressed {
+                self.key_down.insert(key.clone(), true);
+            }
+            if !is_pressed && was_pressed {
+                self.key_up.insert(key.clone(), true);
+            }
+        }
+
+        self.local_cursor_position = event_driven_input.local_cursor_position;
+    }
+
+    pub fn get_key_pressed(&self, str: &str) -> bool {
+        *self.key_pressed.get(&str_to_key(str)).unwrap_or(&false)
+    }
+
+    pub fn get_key_down(&self, str: &str) -> bool {
+        *self.key_down.get(&str_to_key(str)).unwrap_or(&false)
+    }
+
+    pub fn get_key_up(&self, str: &str) -> bool {
+        *self.key_up.get(&str_to_key(str)).unwrap_or(&false)
+    }
+}
+
+fn str_to_key(str: &str) -> Key {
+    match str {
+        "space" => Key::Named(NamedKey::Space),
+        "shift" => Key::Named(NamedKey::Shift),
+        "tab" => Key::Named(NamedKey::Tab),
+        "esc" => Key::Named(NamedKey::Escape),
+        _ => Key::Character(SmolStr::new(str)),
+    }
+}

--- a/lib/src/input.rs
+++ b/lib/src/input.rs
@@ -90,6 +90,7 @@ fn str_to_key(str: &str) -> Key {
         "shift" => Key::Named(NamedKey::Shift),
         "tab" => Key::Named(NamedKey::Tab),
         "esc" => Key::Named(NamedKey::Escape),
+        "ctrl" => Key::Named(NamedKey::Control),
         _ => Key::Character(SmolStr::new(str)),
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,19 +2,8 @@ use std::{cell::RefCell, marker::PhantomData, num::NonZeroU8, rc::Rc, sync::Arc}
 use winit::{
     event::{Event, KeyEvent, WindowEvent},
     event_loop::{EventLoop, EventLoopWindowTarget},
-    keyboard::{Key, KeyCode, NamedKey, SmolStr},
+    keyboard::{Key, NamedKey},
     window::Window,
-};
-
-#[cfg(target_os = "windows")]
-use winapi::um::winuser::SetCursorPos;
-
-#[cfg(target_os = "macos")]
-use core_graphics::{
-    display::CGDisplay,
-    event::{CGEvent, CGEventType, CGMouseButton},
-    event_source::{CGEventSource, CGEventSourceStateID},
-    geometry::CGPoint,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -28,6 +17,7 @@ mod surface_wrapper;
 mod texture;
 mod vertex;
 mod vox;
+mod vox_update;
 
 use context::Context;
 use input::*;
@@ -161,9 +151,11 @@ pub async fn run() {
                         ));
                     }
                 }
+
                 Event::Suspended => {
                     surface.suspend();
                 }
+
                 Event::WindowEvent { event, .. } => match event {
                     WindowEvent::Resized(size) => {
                         surface.resize(&context, size);
@@ -183,6 +175,7 @@ pub async fn run() {
                     | WindowEvent::CloseRequested => {
                         target.exit();
                     }
+
                     #[cfg(not(target_arch = "wasm32"))]
                     WindowEvent::KeyboardInput {
                         event:
@@ -195,7 +188,6 @@ pub async fn run() {
                         println!("{:#?}", context.instance.generate_report());
                     }
 
-                    // key pressed
                     WindowEvent::KeyboardInput {
                         event:
                             KeyEvent {
@@ -215,124 +207,21 @@ pub async fn run() {
                         //
                         // See https://github.com/rust-windowing/winit/issues/3235 for some discussion
 
+                        frame_driven_input.update(&event_driven_input);
+
                         if let Some(vox) = vox.borrow_mut().as_mut() {
-                            // updates
                             {
-                                vox.update(&context.device);
-                                frame_driven_input.update(&event_driven_input);
-                            }
-
-                            // Movement by keyboard
-                            {
-                                if frame_driven_input.get_key_pressed("w")
-                                    && !frame_driven_input.get_key_pressed("s")
-                                {
-                                    let forward_x = -vox.horizontal_rotation.sin();
-                                    let forward_y = vox.horizontal_rotation.cos();
-                                    vox.eye.x += forward_x * 0.1;
-                                    vox.eye.y += forward_y * 0.1;
-                                }
-
-                                if frame_driven_input.get_key_pressed("a")
-                                    && !frame_driven_input.get_key_pressed("d")
-                                {
-                                    let forward_x = -vox.horizontal_rotation.sin();
-                                    let forward_y = vox.horizontal_rotation.cos();
-                                    let leftward_x = -forward_y;
-                                    let leftward_y = forward_x;
-                                    vox.eye.x += leftward_x * 0.1;
-                                    vox.eye.y += leftward_y * 0.1;
-                                }
-
-                                if frame_driven_input.get_key_pressed("s")
-                                    && !frame_driven_input.get_key_pressed("w")
-                                {
-                                    let forward_x = -vox.horizontal_rotation.sin();
-                                    let forward_y = vox.horizontal_rotation.cos();
-                                    vox.eye.x -= forward_x * 0.1;
-                                    vox.eye.y -= forward_y * 0.1;
-                                }
-
-                                if frame_driven_input.get_key_pressed("d")
-                                    && !frame_driven_input.get_key_pressed("a")
-                                {
-                                    let forward_x = -vox.horizontal_rotation.sin();
-                                    let forward_y = vox.horizontal_rotation.cos();
-                                    let rightward_x = forward_y;
-                                    let rightward_y = -forward_x;
-                                    vox.eye.x += rightward_x * 0.1;
-                                    vox.eye.y += rightward_y * 0.1;
-                                }
-
-                                if frame_driven_input.get_key_pressed("space")
-                                    && !frame_driven_input.get_key_pressed("shift")
-                                {
-                                    vox.eye.z += 0.1;
-                                }
-
-                                if frame_driven_input.get_key_pressed("shift")
-                                    && !frame_driven_input.get_key_pressed("str")
-                                {
-                                    vox.eye.z -= 0.1;
-                                }
-                            }
-
-                            // Rotation by mouse
-                            #[cfg(not(target_arch = "wasm32"))]
-                            {
-                                let sensitive: f32 = 0.0015;
                                 if let Ok(window_position) = window_loop.window.inner_position() {
-                                    let window_size = window_loop.window.inner_size();
-                                    let delta_x = event_driven_input.local_cursor_position.x
-                                        - (window_size.width / 2) as f64;
-                                    let delta_y = event_driven_input.local_cursor_position.y
-                                        - (window_size.height / 2) as f64;
-                                    vox.horizontal_rotation -= delta_x as f32 * sensitive;
-                                    vox.horizontal_rotation %= 2.0 * std::f32::consts::PI;
-                                    if vox.horizontal_rotation < 0.0 {
-                                        vox.horizontal_rotation += 2.0 * std::f32::consts::PI;
-                                    }
-
-                                    vox.vertical_rotation -= delta_y as f32 * sensitive;
-                                    vox.vertical_rotation = vox.vertical_rotation.clamp(
-                                        -0.4999 * std::f32::consts::PI,
-                                        0.4999 * std::f32::consts::PI,
+                                    vox.update_window_info(
+                                        window_position,
+                                        window_loop.window.inner_size(),
                                     );
-
-                                    let center_x: i32 =
-                                        window_position.x + (window_size.width / 2) as i32;
-                                    let center_y: i32 =
-                                        window_position.y + (window_size.height / 2) as i32;
-
-                                    #[cfg(target_os = "windows")]
-                                    unsafe {
-                                        SetCursorPos(center_x, center_y);
-                                    }
-
-                                    #[cfg(target_os = "macos")]
-                                    {
-                                        let display_size_os =
-                                            target.primary_monitor().unwrap().size();
-                                        let display_size_cg = CGDisplay::main().bounds().size;
-                                        let scaling_factor =
-                                            display_size_cg.width / display_size_os.width as f64;
-                                        let scaled_x = center_x as f64 * scaling_factor;
-                                        let scaled_y = center_y as f64 * scaling_factor;
-                                        let source = CGEventSource::new(
-                                            CGEventSourceStateID::HIDSystemState,
-                                        )
-                                        .unwrap();
-                                        let event = CGEvent::new_mouse_event(
-                                            source,
-                                            CGEventType::MouseMoved,
-                                            CGPoint::new(scaled_x, scaled_y),
-                                            CGMouseButton::Left,
-                                        )
-                                        .unwrap();
-                                        event.post(core_graphics::event::CGEventTapLocation::HID);
-                                    }
                                 }
+                                vox.update_eye_movement(&frame_driven_input);
+                                vox.update_eye_rotation(&frame_driven_input);
+                                vox.update_nearby_chunks(&context);
                             }
+
                             let frame = surface.acquire(&context);
                             let view = frame.texture.create_view(&wgpu::TextureViewDescriptor {
                                 format: Some(surface.config().view_formats[0]),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -30,7 +30,7 @@ mod vertex;
 mod vox;
 
 use context::Context;
-use input::Input;
+use input::EventDrivenInput;
 use surface_wrapper::SurfaceWrapper;
 use vox::*;
 
@@ -137,7 +137,7 @@ pub async fn run() {
             .expect("Failed to add mousemove event listener");
         closure.forget();
     }
-    let mut input = Input::new();
+    let mut event_driven_input = EventDrivenInput::new();
     let event_loop_function = EventLoop::run;
 
     #[allow(clippy::let_unit_value)]
@@ -199,12 +199,12 @@ pub async fn run() {
                                 logical_key, state, ..
                             },
                         ..
-                    } => input.set_key_state(logical_key, state),
+                    } => event_driven_input.set_key_state(logical_key, state),
 
                     WindowEvent::CursorMoved {
                         position: local_cursor_position,
                         ..
-                    } => input.local_cursor_position = local_cursor_position,
+                    } => event_driven_input.local_cursor_position = local_cursor_position,
 
                     WindowEvent::RedrawRequested => {
                         // On MacOS, currently redraw requested comes in _before_ Init does.
@@ -220,14 +220,18 @@ pub async fn run() {
 
                             // Movement by keyboard
                             {
-                                if input.key_w && !input.key_s {
+                                if event_driven_input.input_state.key_w
+                                    && !event_driven_input.input_state.key_s
+                                {
                                     let forward_x = -vox.horizontal_rotation.sin();
                                     let forward_y = vox.horizontal_rotation.cos();
                                     vox.eye.x += forward_x * 0.1;
                                     vox.eye.y += forward_y * 0.1;
                                 }
 
-                                if input.key_a && !input.key_d {
+                                if event_driven_input.input_state.key_a
+                                    && !event_driven_input.input_state.key_d
+                                {
                                     let forward_x = -vox.horizontal_rotation.sin();
                                     let forward_y = vox.horizontal_rotation.cos();
                                     let leftward_x = -forward_y;
@@ -236,14 +240,18 @@ pub async fn run() {
                                     vox.eye.y += leftward_y * 0.1;
                                 }
 
-                                if input.key_s && !input.key_w {
+                                if event_driven_input.input_state.key_s
+                                    && !event_driven_input.input_state.key_w
+                                {
                                     let forward_x = -vox.horizontal_rotation.sin();
                                     let forward_y = vox.horizontal_rotation.cos();
                                     vox.eye.x -= forward_x * 0.1;
                                     vox.eye.y -= forward_y * 0.1;
                                 }
 
-                                if input.key_d && !input.key_a {
+                                if event_driven_input.input_state.key_d
+                                    && !event_driven_input.input_state.key_a
+                                {
                                     let forward_x = -vox.horizontal_rotation.sin();
                                     let forward_y = vox.horizontal_rotation.cos();
                                     let rightward_x = forward_y;
@@ -252,11 +260,15 @@ pub async fn run() {
                                     vox.eye.y += rightward_y * 0.1;
                                 }
 
-                                if input.key_space && !input.key_shift {
+                                if event_driven_input.input_state.key_space
+                                    && !event_driven_input.input_state.key_shift
+                                {
                                     vox.eye.z += 0.1;
                                 }
 
-                                if input.key_shift && !input.key_space {
+                                if event_driven_input.input_state.key_shift
+                                    && !event_driven_input.input_state.key_space
+                                {
                                     vox.eye.z -= 0.1;
                                 }
                             }
@@ -267,9 +279,9 @@ pub async fn run() {
                                 let sensitive: f32 = 0.0015;
                                 if let Ok(window_position) = window_loop.window.inner_position() {
                                     let window_size = window_loop.window.inner_size();
-                                    let delta_x = input.local_cursor_position.x
+                                    let delta_x = event_driven_input.local_cursor_position.x
                                         - (window_size.width / 2) as f64;
-                                    let delta_y = input.local_cursor_position.y
+                                    let delta_y = event_driven_input.local_cursor_position.y
                                         - (window_size.height / 2) as f64;
                                     vox.horizontal_rotation -= delta_x as f32 * sensitive;
                                     vox.horizontal_rotation %= 2.0 * std::f32::consts::PI;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, marker::PhantomData, num::NonZeroU8, rc::Rc, sync::Arc}
 use winit::{
     event::{Event, KeyEvent, WindowEvent},
     event_loop::{EventLoop, EventLoopWindowTarget},
-    keyboard::{Key, NamedKey},
+    keyboard::{Key, KeyCode, NamedKey, SmolStr},
     window::Window,
 };
 
@@ -30,7 +30,7 @@ mod vertex;
 mod vox;
 
 use context::Context;
-use input::EventDrivenInput;
+use input::*;
 use surface_wrapper::SurfaceWrapper;
 use vox::*;
 
@@ -137,7 +137,10 @@ pub async fn run() {
             .expect("Failed to add mousemove event listener");
         closure.forget();
     }
+
     let mut event_driven_input = EventDrivenInput::new();
+    let mut frame_driven_input = FrameDrivenInput::new();
+
     let event_loop_function = EventLoop::run;
 
     #[allow(clippy::let_unit_value)]
@@ -213,15 +216,16 @@ pub async fn run() {
                         // See https://github.com/rust-windowing/winit/issues/3235 for some discussion
 
                         if let Some(vox) = vox.borrow_mut().as_mut() {
-                            // Vox update
+                            // updates
                             {
                                 vox.update(&context.device);
+                                frame_driven_input.update(&event_driven_input);
                             }
 
                             // Movement by keyboard
                             {
-                                if event_driven_input.input_state.key_w
-                                    && !event_driven_input.input_state.key_s
+                                if frame_driven_input.get_key_pressed("w")
+                                    && !frame_driven_input.get_key_pressed("s")
                                 {
                                     let forward_x = -vox.horizontal_rotation.sin();
                                     let forward_y = vox.horizontal_rotation.cos();
@@ -229,8 +233,8 @@ pub async fn run() {
                                     vox.eye.y += forward_y * 0.1;
                                 }
 
-                                if event_driven_input.input_state.key_a
-                                    && !event_driven_input.input_state.key_d
+                                if frame_driven_input.get_key_pressed("a")
+                                    && !frame_driven_input.get_key_pressed("d")
                                 {
                                     let forward_x = -vox.horizontal_rotation.sin();
                                     let forward_y = vox.horizontal_rotation.cos();
@@ -240,8 +244,8 @@ pub async fn run() {
                                     vox.eye.y += leftward_y * 0.1;
                                 }
 
-                                if event_driven_input.input_state.key_s
-                                    && !event_driven_input.input_state.key_w
+                                if frame_driven_input.get_key_pressed("s")
+                                    && !frame_driven_input.get_key_pressed("w")
                                 {
                                     let forward_x = -vox.horizontal_rotation.sin();
                                     let forward_y = vox.horizontal_rotation.cos();
@@ -249,8 +253,8 @@ pub async fn run() {
                                     vox.eye.y -= forward_y * 0.1;
                                 }
 
-                                if event_driven_input.input_state.key_d
-                                    && !event_driven_input.input_state.key_a
+                                if frame_driven_input.get_key_pressed("d")
+                                    && !frame_driven_input.get_key_pressed("a")
                                 {
                                     let forward_x = -vox.horizontal_rotation.sin();
                                     let forward_y = vox.horizontal_rotation.cos();
@@ -260,14 +264,14 @@ pub async fn run() {
                                     vox.eye.y += rightward_y * 0.1;
                                 }
 
-                                if event_driven_input.input_state.key_space
-                                    && !event_driven_input.input_state.key_shift
+                                if frame_driven_input.get_key_pressed("space")
+                                    && !frame_driven_input.get_key_pressed("shift")
                                 {
                                     vox.eye.z += 0.1;
                                 }
 
-                                if event_driven_input.input_state.key_shift
-                                    && !event_driven_input.input_state.key_space
+                                if frame_driven_input.get_key_pressed("shift")
+                                    && !frame_driven_input.get_key_pressed("str")
                                 {
                                     vox.eye.z -= 0.1;
                                 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -157,7 +157,7 @@ pub async fn run() {
                 }
 
                 Event::WindowEvent { event, .. } => match event {
-                    WindowEvent::Resized(size) => {
+                    /* WindowEvent::Resized(size) => {
                         surface.resize(&context, size);
                         if let Some(vox) = vox.borrow_mut().as_mut() {
                             vox.resize(surface.config(), &context.device, &context.queue);
@@ -172,7 +172,8 @@ pub async fn run() {
                             },
                         ..
                     }
-                    | WindowEvent::CloseRequested => {
+                    |  */
+                    WindowEvent::CloseRequested => {
                         target.exit();
                     }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -157,14 +157,14 @@ pub async fn run() {
                 }
 
                 Event::WindowEvent { event, .. } => match event {
-                    /* WindowEvent::Resized(size) => {
+                    WindowEvent::Resized(size) => {
                         surface.resize(&context, size);
                         if let Some(vox) = vox.borrow_mut().as_mut() {
                             vox.resize(surface.config(), &context.device, &context.queue);
                         }
                         window_loop.window.request_redraw();
                     }
-                    WindowEvent::KeyboardInput {
+                    /* WindowEvent::KeyboardInput {
                         event:
                             KeyEvent {
                                 logical_key: Key::Named(NamedKey::Escape),

--- a/lib/src/vox.rs
+++ b/lib/src/vox.rs
@@ -8,7 +8,7 @@ use wgpu::util::DeviceExt;
 use winit::dpi::PhysicalPosition;
 use winit::dpi::PhysicalSize;
 
-pub const RENDER_DISTANCE: f32 = 21.0;
+pub const RENDER_DISTANCE: f32 = 5.0;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
@@ -22,7 +22,7 @@ pub struct Vox {
     pub vertical_rotation: f32,
     pub window_inner_position: PhysicalPosition<i32>,
     pub window_inner_size: PhysicalSize<u32>,
-    pub mouse_lock: bool,
+    pub is_paused: bool,
     projection_matrix: glam::Mat4,
     depth_buffer: wgpu::TextureView,
     map: Map,
@@ -284,7 +284,7 @@ impl Vox {
             pipeline,
             window_inner_position: PhysicalPosition::new(0, 0),
             window_inner_size: PhysicalSize::new(0, 0),
-            mouse_lock: true,
+            is_paused: true,
         }
     }
 

--- a/lib/src/vox.rs
+++ b/lib/src/vox.rs
@@ -1,13 +1,14 @@
+use crate::lru_cache::LRUCache;
 use crate::map::*;
 use crate::texture::*;
 use crate::vertex::*;
 use bytemuck::{Pod, Zeroable};
 use std::{borrow::Cow, collections::BTreeMap, f32::consts, mem, rc::Rc};
 use wgpu::util::DeviceExt;
+use winit::dpi::PhysicalPosition;
+use winit::dpi::PhysicalSize;
 
-use crate::lru_cache::LRUCache;
-
-const RENDER_DISTANCE: f32 = 6.0;
+pub const RENDER_DISTANCE: f32 = 6.0;
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
@@ -19,6 +20,9 @@ pub struct Vox {
     pub eye: glam::Vec3,
     pub horizontal_rotation: f32,
     pub vertical_rotation: f32,
+    pub window_inner_position: PhysicalPosition<i32>,
+    pub window_inner_size: PhysicalSize<u32>,
+    pub mouse_lock: bool,
     projection_matrix: glam::Mat4,
     depth_buffer: wgpu::TextureView,
     map: Map,
@@ -38,7 +42,7 @@ impl Vox {
         Rc::clone(self.chunks.get(&[x, y, z]).unwrap())
     }
 
-    fn get_buffers(
+    pub fn get_buffers(
         &mut self,
         device: &wgpu::Device,
         x: i32,
@@ -278,10 +282,13 @@ impl Vox {
             bind_group,
             uniform_vp_buffer,
             pipeline,
+            window_inner_position: PhysicalPosition::new(0, 0),
+            window_inner_size: PhysicalSize::new(0, 0),
+            mouse_lock: true,
         }
     }
 
-    fn get_coords(distance: f32) -> Vec<(i32, i32, i32)> {
+    pub fn get_coords(distance: f32) -> Vec<(i32, i32, i32)> {
         let mut coords = Vec::new();
         let max_coord = distance.floor() as i32;
         let distance_squared = distance * distance;
@@ -298,20 +305,6 @@ impl Vox {
         }
 
         coords
-    }
-
-    pub fn update(&mut self, device: &wgpu::Device) {
-        let coords = Self::get_coords(RENDER_DISTANCE);
-        let where_am_i = self.eye.floor() / CHUNK_SIZE as f32;
-        for coord in coords.iter() {
-            self.get_buffers(
-                device,
-                coord.0 + where_am_i.x as i32,
-                coord.1 + where_am_i.y as i32,
-                coord.2 + where_am_i.z as i32,
-            );
-        }
-        // println!("buffers size: {}", self.buffers.len());
     }
 
     pub fn resize(

--- a/lib/src/vox_update.rs
+++ b/lib/src/vox_update.rs
@@ -1,0 +1,153 @@
+use crate::context::Context;
+use crate::input::*;
+use crate::map::*;
+use crate::vox::*;
+use winit::dpi::PhysicalPosition;
+use winit::dpi::PhysicalSize;
+
+#[cfg(target_os = "windows")]
+use winapi::um::winuser::SetCursorPos;
+
+#[cfg(target_os = "macos")]
+use core_graphics::{
+    display::CGDisplay,
+    event::{CGEvent, CGEventType, CGMouseButton},
+    event_source::{CGEventSource, CGEventSourceStateID},
+    geometry::CGPoint,
+};
+
+/// [ Speed in Minecraft ]
+/// Walking speed: 4.317 blocks/second
+/// Sprinting speed (Survival): 5.612 blocks/second
+/// Flying speed (Creative): 10.89 blocks/second
+
+const MOVE_SPEED: f32 = 4.317;
+const FAST_MOVE_SPEED: f32 = 10.89;
+
+const FPS: f32 = 60.0;
+
+impl Vox {
+    pub fn update_window_info(
+        &mut self,
+        window_inner_position: PhysicalPosition<i32>,
+        window_inner_size: PhysicalSize<u32>,
+    ) {
+        self.window_inner_position = window_inner_position;
+        self.window_inner_size = window_inner_size;
+    }
+
+    pub fn update_eye_movement(&mut self, input: &FrameDrivenInput) {
+        let speed = if input.get_key_pressed("ctrl") {
+            FAST_MOVE_SPEED / FPS
+        } else {
+            MOVE_SPEED / FPS
+        };
+        if input.get_key_pressed("w") && !input.get_key_pressed("s") {
+            let forward_x = -self.horizontal_rotation.sin();
+            let forward_y = self.horizontal_rotation.cos();
+            self.eye.x += forward_x * speed;
+            self.eye.y += forward_y * speed;
+        }
+
+        if input.get_key_pressed("a") && !input.get_key_pressed("d") {
+            let forward_x = -self.horizontal_rotation.sin();
+            let forward_y = self.horizontal_rotation.cos();
+            let leftward_x = -forward_y;
+            let leftward_y = forward_x;
+            self.eye.x += leftward_x * speed;
+            self.eye.y += leftward_y * speed;
+        }
+
+        if input.get_key_pressed("s") && !input.get_key_pressed("w") {
+            let forward_x = -self.horizontal_rotation.sin();
+            let forward_y = self.horizontal_rotation.cos();
+            self.eye.x -= forward_x * speed;
+            self.eye.y -= forward_y * speed;
+        }
+
+        if input.get_key_pressed("d") && !input.get_key_pressed("a") {
+            let forward_x = -self.horizontal_rotation.sin();
+            let forward_y = self.horizontal_rotation.cos();
+            let rightward_x = forward_y;
+            let rightward_y = -forward_x;
+            self.eye.x += rightward_x * speed;
+            self.eye.y += rightward_y * speed;
+        }
+
+        if input.get_key_pressed("space") && !input.get_key_pressed("shift") {
+            self.eye.z += 0.1;
+        }
+
+        if input.get_key_pressed("shift") && !input.get_key_pressed("str") {
+            self.eye.z -= 0.1;
+        }
+    }
+
+    pub fn update_eye_rotation(&mut self, input: &FrameDrivenInput) {
+        if input.get_key_down("tab") {
+            self.mouse_lock = !self.mouse_lock;
+        }
+        if !self.mouse_lock {
+            return;
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let sensitive: f32 = 0.0015;
+            let window_position = self.window_inner_position;
+            let window_size = self.window_inner_size;
+            let delta_x = input.local_cursor_position.x - (window_size.width / 2) as f64;
+            let delta_y = input.local_cursor_position.y - (window_size.height / 2) as f64;
+            self.horizontal_rotation -= delta_x as f32 * sensitive;
+            self.horizontal_rotation %= 2.0 * std::f32::consts::PI;
+            if self.horizontal_rotation < 0.0 {
+                self.horizontal_rotation += 2.0 * std::f32::consts::PI;
+            }
+
+            self.vertical_rotation -= delta_y as f32 * sensitive;
+            self.vertical_rotation = self.vertical_rotation.clamp(
+                -0.4999 * std::f32::consts::PI,
+                0.4999 * std::f32::consts::PI,
+            );
+
+            let center_x: i32 = window_position.x + (window_size.width / 2) as i32;
+            let center_y: i32 = window_position.y + (window_size.height / 2) as i32;
+
+            #[cfg(target_os = "windows")]
+            unsafe {
+                SetCursorPos(center_x, center_y);
+            }
+
+            #[cfg(target_os = "macos")]
+            {
+                let display_size_os = target.primary_monitor().unwrap().size();
+                let display_size_cg = CGDisplay::main().bounds().size;
+                let scaling_factor = display_size_cg.width / display_size_os.width as f64;
+                let scaled_x = center_x as f64 * scaling_factor;
+                let scaled_y = center_y as f64 * scaling_factor;
+                let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).unwrap();
+                let event = CGEvent::new_mouse_event(
+                    source,
+                    CGEventType::MouseMoved,
+                    CGPoint::new(scaled_x, scaled_y),
+                    CGMouseButton::Left,
+                )
+                .unwrap();
+                event.post(core_graphics::event::CGEventTapLocation::HID);
+            }
+        }
+    }
+
+    pub fn update_nearby_chunks(&mut self, context: &Context) {
+        let coords = Self::get_coords(RENDER_DISTANCE);
+        let where_am_i = self.eye.floor() / CHUNK_SIZE as f32;
+        for coord in coords.iter() {
+            self.get_buffers(
+                &context.device,
+                coord.0 + where_am_i.x as i32,
+                coord.1 + where_am_i.y as i32,
+                coord.2 + where_am_i.z as i32,
+            );
+        }
+    }
+}


### PR DESCRIPTION
- vox모듈을 vox, vox_update 모듈로 분리
- vox_update은 프레임마다 호출되어야하는 update 함수들만 모아둠
---
- Input 모듈 기능 추가
- EventDrivenInput은 이벤트가 발생할 때마다 업데이트되는 구조체
- FrameDrivenInput은 프레임마다 업데이트되는 구조체. 필요한 이유는 Key가 어떤 프레임에 Up/Down되었는지를 확인하기 위해. 기존의 EventDrivenInput(구 Input)은 이벤트마다 업데이트되기때문에 키가 눌렸을 때 해당 프레임에서 감지하기가 힘듬. 따라서 Frame단위로 업데이트되는 FrameDrivenInput이 필요함.
---
- ESC키로 프로그램 종료되는 이벤트 삭제
- 대신 ESC키를 누르면 Mouse Lock이 풀리고, 창닫기 버튼으로 종료가능(Alt + F4도 가능)
- 마우스가 항상 Lock되어있으니 불편해서 추가한 기능
- 다시 ESC 누르면 돌아옴
---
- Movement 로직 변경
- 기존 움직임은 W와 A를 동시에 누르면 sqrt(2)의 속도로 더 빠르게 움직이는 문제가 있었음.
- 방향키를 여러개 누르면서 대각선으로 이동하더라도 동일한 속도를 유지하도록 수정
---
- 기본 속도 변경
- 4.317 Block/second. 마인크래프트의 기본 걷기 속도
---
- 변경된 키보드 조작
- WASD + Shift + Space : xyz방향 이동
- ESC: 마우스 Lock 설정/해제 토글
- CTRL: 빠르게 이동 (초당 10.89블럭 이동, 마인크래프트의 크레이티브 모드 비행 속도)
