### PR TITLE
remove LRUCache in Native Worker(add VecDeque)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -170,10 +170,11 @@ impl<T: TerrainWorker> Vox<T> {
             (eye.x as i32, eye.y as i32, eye.z as i32)
         };
 
-        for ((x, y, z), chunk) in self
+        let res = self
             .terrain_worker
-            .get_available(CACHE_DISTANCE, (self.eye.x, self.eye.y, self.eye.z))
-        {
+            .get_available(CACHE_DISTANCE, (self.eye.x, self.eye.y, self.eye.z));
+
+        for ((x, y, z), chunk) in res {
             self.chunks.insert([x, y, z], chunk);
         }
 


### PR DESCRIPTION
LRU 캐시 삭제 후, VecDeque로 스레드에서 만든 청크를 ChunkCache로 옮기는 로직으로 변경.

여전히 60프레임이 안나오는 중. 

## 첨부
![image](https://github.com/user-attachments/assets/d06478c8-a973-4193-a897-2e44bd66fee5)
